### PR TITLE
remove maxBodyLength limit

### DIFF
--- a/src/client/BaseClient.ts
+++ b/src/client/BaseClient.ts
@@ -170,6 +170,7 @@ export default abstract class BaseClient {
             timeout: this.getRequestTimeoutInSeconds(),
             responseType: "json",
             maxContentLength: Infinity,
+            maxBodyLength: Infinity,
             validateStatus(status) {
                 return status >= 200 && status < 300;
             },


### PR DESCRIPTION
When sending a long email or when attaching documents the `maxBodyLength` can lead to failure of a batch send. This fix resolves that issue.